### PR TITLE
fix: fix app crash on .AppImage and Macos

### DIFF
--- a/src-tauri/src/app.rs
+++ b/src-tauri/src/app.rs
@@ -56,11 +56,14 @@ pub fn get_app_home_dir() -> PathBuf {
   }
 
   #[cfg(not(target_os = "windows"))]
-  if let Err(e) = home_dir() {
-    error!("Failed to get app home dir. Errmsg: {}", e);
-    std::process::exit(-1);
-  } else {
-    return current_dir().unwrap().join(APP_DIR);
+  match home_dir() {
+    None => {
+      error!("Failed to get app home dir");
+      std::process::exit(-1);      
+    },
+    Some(path) => {
+      return path.join(APP_DIR);
+    }
   }
 }
 

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -24,6 +24,7 @@ use std::path::Path;
  * to specific log pattern, see https://docs.rs/log4rs/latest/log4rs/encode/pattern/
  */
 pub fn initialize_logger(log_file_path: &str) {
+    println!("log file path: {}", log_file_path);
     // define log level filter
     let global_log_level = LevelFilter::Debug;
     let stdout_log_level = LevelFilter::Debug;

--- a/src-tauri/src/logger.rs
+++ b/src-tauri/src/logger.rs
@@ -24,7 +24,6 @@ use std::path::Path;
  * to specific log pattern, see https://docs.rs/log4rs/latest/log4rs/encode/pattern/
  */
 pub fn initialize_logger(log_file_path: &str) {
-    println!("log file path: {}", log_file_path);
     // define log level filter
     let global_log_level = LevelFilter::Debug;
     let stdout_log_level = LevelFilter::Debug;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,7 +12,7 @@ mod handler;
 mod modules;
 
 // Module related
-use app::{ create_system_tray, handle_system_tray_event, handle_app_event, initialize_window_shadow };
+use app::{ get_app_log_dir, create_system_tray, handle_system_tray_event, handle_app_event, initialize_window_shadow };
 use handler::{ MissionHandler, MissionHandlerWrapper, initialize_cron_scheduler, AutoStartHandler, AutoStartHandlerWrapper };
 
 // Plugin related
@@ -31,7 +31,8 @@ use tauri::Manager;
 
 fn main() {
   // initialize log
-  logger::initialize_logger("logs/output.log");
+  let app_log_dir = get_app_log_dir();
+  logger::initialize_logger(app_log_dir.join("output.log").to_str().unwrap());
 
   // initialize plugins
   // failed to build on linux and macos 


### PR DESCRIPTION
Due to path format requirement, if app wants to creat some files, the given path must be absolute and clear.
For more details, check this issue https://github.com/tauri-apps/tauri/issues/5672